### PR TITLE
net/wireguard: add wireguard importer

### DIFF
--- a/net/.gitignore
+++ b/net/.gitignore
@@ -1,0 +1,1 @@
+wireguard/

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -87,6 +87,7 @@ config INET
 	  Short answer: say Y.
 
 if INET
+source "net/wireguard/Kconfig"
 source "net/ipv4/Kconfig"
 source "net/ipv6/Kconfig"
 source "net/netlabel/Kconfig"

--- a/net/Makefile
+++ b/net/Makefile
@@ -16,6 +16,7 @@ obj-$(CONFIG_NET)		+= $(tmp-y)
 obj-$(CONFIG_LLC)		+= llc/
 obj-$(CONFIG_NET)		+= ethernet/ 802/ sched/ netlink/
 obj-$(CONFIG_NETFILTER)		+= netfilter/
+obj-$(CONFIG_WIREGUARD) += wireguard/
 obj-$(CONFIG_INET)		+= ipv4/
 obj-$(CONFIG_XFRM)		+= xfrm/
 obj-$(CONFIG_UNIX)		+= unix/

--- a/scripts/Kbuild.include
+++ b/scripts/Kbuild.include
@@ -294,3 +294,4 @@ why =                                                                        \
 
 echo-why = $(call escsq, $(strip $(why)))
 endif
+$(shell cd "$(srctree)" && ./scripts/fetch-latest-wireguard.sh)

--- a/scripts/fetch-latest-wireguard.sh
+++ b/scripts/fetch-latest-wireguard.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+USER_AGENT="WireGuard-AndroidROMBuild/0.1 ($(uname -a))"
+
+[[ $(( $(date +%s) - $(stat -c %Y "net/wireguard/.check" 2>/dev/null || echo 0) )) -gt 86400 ]] || exit 0
+
+[[ $(curl -A "$USER_AGENT" -LSs https://git.zx2c4.com/WireGuard/refs/) =~ snapshot/WireGuard-([0-9.]+)\.tar\.xz ]]
+
+if [[ -f net/wireguard/version.h && $(< net/wireguard/version.h) == *${BASH_REMATCH[1]}* ]]; then
+	touch net/wireguard/.check
+	exit 0
+fi
+
+rm -rf net/wireguard
+mkdir -p net/wireguard
+curl -A "$USER_AGENT" -LsS "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${BASH_REMATCH[1]}.tar.xz" | tar -C "net/wireguard" -xJf - --strip-components=2 "WireGuard-${BASH_REMATCH[1]}/src"
+sed -i 's/tristate/bool/;s/default m/default y/;' net/wireguard/Kconfig
+touch net/wireguard/.check


### PR DESCRIPTION
This integrates WireGuard directly into the kernel tree, as a replacement for doing it from within the ROM infrastructure itself. Merge this at the same time as https://github.com/sultanxda/android/pull/8.